### PR TITLE
list to heredoc for instructions

### DIFF
--- a/ragstar/chatbot.py
+++ b/ragstar/chatbot.py
@@ -58,25 +58,20 @@ class Chatbot:
             openai_api_key, embedding_model, db_persist_path
         )
 
-        self.__instructions: list[str] = [
-            "You are a data analyst working with a data warehouse.",
-            "You should provide the user with the information they need to answer their question.",
-            "You should only provide information that you are confident is correct.",
-            "When you are not sure about the answer, you should let the user know.",
-            "If you are able to construct a SQL query that would answer the user's question, you should do so.",
-            "However please refrain from doing so if the user's question is ambiguous or unclear.",
-            "When writing a SQL query, you should only use column values if these values have been explicitly"
-            + " provided to you in the information you have been given.",
-            "Do not write a SQL query if you are unsure about the correctness of the query or"
-            + " about the values contained in the columns.",
-            "Only write a SQL query if you are confident that the query is exhaustive"
-            + " and that it will return the correct results.",
-            "If it is not possible to write a SQL that fulfils these conditions, you should instead respond"
-            + " with the names of the tables or columns that you think are relevant to the user's question.",
-            "You should also refrain from providing any information that is not directly related to the"
-            + " user's question or that which cannot be inferred from the information you have been given.",
-            "The following information about tables and columns is available to you:",
-        ]
+        self.__instructions: list[str] = ["""
+You are a data analyst working with a data warehouse.
+You should provide the user with the information they need to answer their question.
+You should only provide information that you are confident is correct.
+When you are not sure about the answer, you should let the user know.
+If you are able to construct a SQL query that would answer the user's question, you should do so.
+However please refrain from doing so if the user's question is ambiguous or unclear.
+When writing a SQL query, you should only use column values if these values have been explicitly provided to you in the information you have been given.
+Do not write a SQL query if you are unsure about the correctness of the query or about the values contained in the columns.
+Only write a SQL query if you are confident that the query is exhaustive and that it will return the correct results.
+If it is not possible to write a SQL that fulfils these conditions, you should instead respond with the names of the tables or columns that you think are relevant to the user's question.
+You should also refrain from providing any information that is not directly related to the user's question or that which cannot be inferred from the information you have been given.
+The following information about tables and columns is available to you:
+"""]
 
     def __prepare_prompt(
         self, closest_models: list[ParsedSearchResult], query: str


### PR DESCRIPTION
I'm not sure what you're trying to do here by making instructions a list, but this prompt is a single string, so better to store as heredoc.

I can't test locally since I don't have a good dataset to play with, so not changing too much.  Looks like get_instructions isn't used anywhere...  I'm guessing you're imagining the user will get and then set instructions if they want to override.

This is fine, but I prefer using a template pattern (maybe old school).

```
class MyCustomerChatBot(ChatBot):

     def get_instructions(self):  
          # Blah blah

```

